### PR TITLE
天気予報APIのエラーハンドリング

### DIFF
--- a/YumemiTraining/YumemiTraining/ViewController.swift
+++ b/YumemiTraining/YumemiTraining/ViewController.swift
@@ -59,7 +59,7 @@ final class ViewController: UIViewController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)
         alert.addAction(cancelAction)
-        present(alert, animated: true)
+        self.present(alert, animated: true)
     }
 }
 


### PR DESCRIPTION
## 概要 

[Session3. エラーハンドリング](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md)

## 修正内容 

- 呼び出しAPIを`Throws ver`に変更
- APIエラーが発生したらUIAlertControllerを表示

|after| 
|-----|
|<img width="361" alt="スクリーンショット 2022-03-02 13 52 20" src="https://user-images.githubusercontent.com/67317828/156297443-4f420f03-c0c9-4cc2-867e-f4384cd398e0.png">|