### PR TITLE
ページ遷移後に天気予報を表示

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		B3AF310527BF99EE00A7C1DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */; };
 		B3AF310727BF99EE00A7C1DB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */; };
-		B3AF310927BF99EE00A7C1DB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310827BF99EE00A7C1DB /* ViewController.swift */; };
+		B3AF310927BF99EE00A7C1DB /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310827BF99EE00A7C1DB /* WeatherViewController.swift */; };
 		B3AF310C27BF99EE00A7C1DB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3AF310A27BF99EE00A7C1DB /* Main.storyboard */; };
 		B3AF310E27BF99EF00A7C1DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B3AF310D27BF99EF00A7C1DB /* Assets.xcassets */; };
 		B3AF311127BF99EF00A7C1DB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3AF310F27BF99EF00A7C1DB /* LaunchScreen.storyboard */; };
@@ -17,13 +17,15 @@
 		B3D5259427D1AA93002D7A4D /* WeatherParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5259327D1AA93002D7A4D /* WeatherParameter.swift */; };
 		B3D5259627D1AAF0002D7A4D /* WeatherResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5259527D1AAF0002D7A4D /* WeatherResult.swift */; };
 		B3D5259927D1B112002D7A4D /* WeatherAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5259827D1B112002D7A4D /* WeatherAPI.swift */; };
+		B3D5259C27D1BD68002D7A4D /* WeatherViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */; };
+		B3D5259E27D1BEA3002D7A4D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5259D27D1BEA3002D7A4D /* ViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		B3AF310127BF99EE00A7C1DB /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		B3AF310827BF99EE00A7C1DB /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B3AF310827BF99EE00A7C1DB /* WeatherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewController.swift; sourceTree = "<group>"; };
 		B3AF310B27BF99EE00A7C1DB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		B3AF310D27BF99EF00A7C1DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B3AF311027BF99EF00A7C1DB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -31,6 +33,8 @@
 		B3D5259327D1AA93002D7A4D /* WeatherParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherParameter.swift; sourceTree = "<group>"; };
 		B3D5259527D1AAF0002D7A4D /* WeatherResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResult.swift; sourceTree = "<group>"; };
 		B3D5259827D1B112002D7A4D /* WeatherAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPI.swift; sourceTree = "<group>"; };
+		B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WeatherViewController.storyboard; sourceTree = "<group>"; };
+		B3D5259D27D1BEA3002D7A4D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,10 +70,12 @@
 			children = (
 				B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */,
 				B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */,
-				B3AF310827BF99EE00A7C1DB /* ViewController.swift */,
+				B3D5259D27D1BEA3002D7A4D /* ViewController.swift */,
+				B3AF310827BF99EE00A7C1DB /* WeatherViewController.swift */,
 				B3D5259A27D1B1D6002D7A4D /* APIs */,
 				B3D5259727D1B0B8002D7A4D /* Models */,
 				B3AF310A27BF99EE00A7C1DB /* Main.storyboard */,
+				B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */,
 				B3AF310D27BF99EF00A7C1DB /* Assets.xcassets */,
 				B3AF310F27BF99EF00A7C1DB /* LaunchScreen.storyboard */,
 				B3AF311227BF99EF00A7C1DB /* Info.plist */,
@@ -158,6 +164,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3D5259C27D1BD68002D7A4D /* WeatherViewController.storyboard in Resources */,
 				B3AF311127BF99EF00A7C1DB /* LaunchScreen.storyboard in Resources */,
 				B3AF310E27BF99EF00A7C1DB /* Assets.xcassets in Resources */,
 				B3AF310C27BF99EE00A7C1DB /* Main.storyboard in Resources */,
@@ -173,8 +180,9 @@
 			files = (
 				B3D5259627D1AAF0002D7A4D /* WeatherResult.swift in Sources */,
 				B3D5259927D1B112002D7A4D /* WeatherAPI.swift in Sources */,
-				B3AF310927BF99EE00A7C1DB /* ViewController.swift in Sources */,
+				B3AF310927BF99EE00A7C1DB /* WeatherViewController.swift in Sources */,
 				B3AF310527BF99EE00A7C1DB /* AppDelegate.swift in Sources */,
+				B3D5259E27D1BEA3002D7A4D /* ViewController.swift in Sources */,
 				B3D5259427D1AA93002D7A4D /* WeatherParameter.swift in Sources */,
 				B3AF310727BF99EE00A7C1DB /* SceneDelegate.swift in Sources */,
 			);

--- a/YumemiTraining/YumemiTraining/Base.lproj/Main.storyboard
+++ b/YumemiTraining/YumemiTraining/Base.lproj/Main.storyboard
@@ -3,9 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,89 +14,13 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="TO7-OE-Kp7" userLabel="MainStackView">
-                                <rect key="frame" x="103.5" y="331.5" width="207" height="243"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iLo-YF-PhL">
-                                        <rect key="frame" x="0.0" y="0.0" width="207" height="207"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="iLo-YF-PhL" secondAttribute="height" id="L25-eD-8nu"/>
-                                        </constraints>
-                                    </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="DS6-Iu-KSd" userLabel="LabelStackView">
-                                        <rect key="frame" x="0.0" y="207" width="207" height="36"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bo2-9X-vtS">
-                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="36"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                                <color key="textColor" name="Blue"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j6t-gW-YGY">
-                                                <rect key="frame" x="103.5" y="0.0" width="103.5" height="36"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                                <color key="textColor" name="Red"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="CcG-tk-LZg" userLabel="ButtonStackView">
-                                <rect key="frame" x="103.5" y="654.5" width="207" height="32"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EG8-b7-jVg">
-                                        <rect key="frame" x="0.0" y="0.0" width="103.5" height="32"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Close">
-                                            <fontDescription key="titleFontDescription" type="system" weight="medium" pointSize="15"/>
-                                        </buttonConfiguration>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nox-y5-K0O">
-                                        <rect key="frame" x="103.5" y="0.0" width="103.5" height="32"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Reload">
-                                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
-                                        </buttonConfiguration>
-                                        <connections>
-                                            <action selector="reloadButtonDidPress:" destination="BYZ-38-t0r" eventType="touchUpInside" id="t6Q-9J-1YT"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                            </stackView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="CcG-tk-LZg" firstAttribute="width" secondItem="TO7-OE-Kp7" secondAttribute="width" id="CSp-Ia-iMh"/>
-                            <constraint firstItem="TO7-OE-Kp7" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="Hby-Pz-M4P"/>
-                            <constraint firstItem="TO7-OE-Kp7" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="V2i-74-ZEL"/>
-                            <constraint firstItem="CcG-tk-LZg" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="bLA-fp-a9k"/>
-                            <constraint firstItem="CcG-tk-LZg" firstAttribute="top" secondItem="TO7-OE-Kp7" secondAttribute="bottom" constant="80" id="c8q-mj-vTB"/>
-                            <constraint firstItem="TO7-OE-Kp7" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="h08-Cs-jEi"/>
-                        </constraints>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
-                    <connections>
-                        <outlet property="maxTempLabel" destination="j6t-gW-YGY" id="1ko-6z-XfL"/>
-                        <outlet property="minTempLabel" destination="Bo2-9X-vtS" id="4Uw-fl-jjM"/>
-                        <outlet property="weatherImageView" destination="iLo-YF-PhL" id="WmI-jY-TvN"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="18.840579710144929" y="84.375"/>
         </scene>
     </scenes>
-    <resources>
-        <namedColor name="Blue">
-            <color red="0.20499999821186066" green="0.53700000047683716" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="Red">
-            <color red="1" green="0.210999995470047" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/YumemiTraining/YumemiTraining/ViewController.swift
+++ b/YumemiTraining/YumemiTraining/ViewController.swift
@@ -2,75 +2,41 @@
 //  ViewController.swift
 //  YumemiTraining
 //
-//  Created by 水野虎樹 on 2022/02/18.
+//  Created by 水野虎樹 on 2022/03/04.
 //
 
 import UIKit
-import YumemiWeather
+
+enum MainError: Error {
+    case weatherViewControllerNotFound
+}
 
 final class ViewController: UIViewController {
-    
-    @IBOutlet private weak var weatherImageView: UIImageView!
-    @IBOutlet private weak var maxTempLabel: UILabel!
-    @IBOutlet private weak var minTempLabel: UILabel!
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.loadWeather()
-    }
-
-    @IBAction private func reloadButtonDidPress(_ sender: Any) {
-        self.loadWeather()
-    }
-    
-    private func loadWeather() {
-        
         do {
-            // WeatherPrameterを作成
-            let weatherPrameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
-            
-            // 天気予報をAPIから取得
-            let weatherResult = try WeatherAPIService.fetchWeather(weatherPrameter)
-            
-            // 天気の画像を設定
-            let weatherImageResource = self.weatherImageResource(weatherResult.weather)
-            self.weatherImageView.image = weatherImageResource.image
-            self.weatherImageView.tintColor = weatherImageResource.color
-            
-            //最高気温と最低気温を設定
-            self.minTempLabel.text = String(weatherResult.minTemp)
-            self.maxTempLabel.text = String(weatherResult.maxTemp)
-            
-        } catch YumemiWeatherError.invalidParameterError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "invalidParameterError")
-        } catch YumemiWeatherError.unknownError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "unknownError")
+            try self.showWeatherViewController()
         } catch {
             print(error)
         }
-        
     }
     
-    private func weatherImageResource(_ weather: String) -> (image: UIImage?, color: UIColor?) {
+    private func showWeatherViewController() throws {
         
-        switch weather {
-        case "sunny":
-            return (UIImage(named: "sunny"), .red)
-        case "cloudy":
-            return (UIImage(named: "cloudy"), .gray)
-        case "rainy":
-            return (UIImage(named: "rainy"), .blue)
-        default:
-            return (nil, nil)
+        let storyboard = UIStoryboard(name: "WeatherViewController", bundle: nil)
+        let viewController = storyboard.instantiateInitialViewController { (coder) in
+            WeatherViewController(coder: coder)
         }
-        
-    }
-    
-    private func showErrorAlert(title: String?, message: String?) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)
-        alert.addAction(cancelAction)
-        self.present(alert, animated: true)
+        guard let viewController = viewController else {
+            throw MainError.weatherViewControllerNotFound
+        }
+        viewController.delegate = self
+        self.present(viewController, animated: true)
     }
 }
 
+extension ViewController: WeatherViewControllerDelegate {
+    func weatherViewControllerDidPressClose(_ viewController: WeatherViewController) {
+        self.dismiss(animated: true)
+    }
+}

--- a/YumemiTraining/YumemiTraining/ViewController.swift
+++ b/YumemiTraining/YumemiTraining/ViewController.swift
@@ -35,6 +35,8 @@ final class ViewController: UIViewController {
     }
 }
 
+// MARK: - WeatherViewControllerDelegate
+
 extension ViewController: WeatherViewControllerDelegate {
     func weatherViewControllerDidPressClose(_ viewController: WeatherViewController) {
         self.dismiss(animated: true)

--- a/YumemiTraining/YumemiTraining/ViewController.swift
+++ b/YumemiTraining/YumemiTraining/ViewController.swift
@@ -7,10 +7,6 @@
 
 import UIKit
 
-enum MainError: Error {
-    case weatherViewControllerNotFound
-}
-
 final class ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/YumemiTraining/YumemiTraining/ViewController.swift
+++ b/YumemiTraining/YumemiTraining/ViewController.swift
@@ -28,7 +28,7 @@ final class ViewController: UIViewController {
             WeatherViewController(coder: coder)
         }
         guard let viewController = viewController else {
-            throw MainError.weatherViewControllerNotFound
+            fatalError()
         }
         viewController.delegate = self
         self.present(viewController, animated: true)

--- a/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AUM-E2-vVA">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Weather View Controller-->
+        <scene sceneID="MUS-n8-Oys">
+            <objects>
+                <viewController modalPresentationStyle="fullScreen" id="AUM-E2-vVA" customClass="WeatherViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wtM-GD-Zcf">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ztZ-SV-NeE" userLabel="MainStackView">
+                                <rect key="frame" x="103.5" y="331.5" width="207" height="243"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Z6I-AM-SIB">
+                                        <rect key="frame" x="0.0" y="0.0" width="207" height="207"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="Z6I-AM-SIB" secondAttribute="height" id="pKt-Rn-1jz"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tWP-xv-5eE" userLabel="LabelStackView">
+                                        <rect key="frame" x="0.0" y="207" width="207" height="36"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w2X-kR-aOX">
+                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="36"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                                <color key="textColor" name="Blue"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W3M-f4-efm">
+                                                <rect key="frame" x="103.5" y="0.0" width="103.5" height="36"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                                <color key="textColor" name="Red"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="20I-Iy-tuF" userLabel="ButtonStackView">
+                                <rect key="frame" x="103.5" y="654.5" width="207" height="32"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rGR-aS-bt9">
+                                        <rect key="frame" x="0.0" y="0.0" width="103.5" height="32"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Close">
+                                            <fontDescription key="titleFontDescription" type="system" weight="medium" pointSize="15"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="closeButtonDidPress:" destination="AUM-E2-vVA" eventType="touchUpInside" id="FdF-LO-yFD"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ded-fG-kAR">
+                                        <rect key="frame" x="103.5" y="0.0" width="103.5" height="32"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Reload">
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="reloadButtonDidPress:" destination="AUM-E2-vVA" eventType="touchUpInside" id="Hbz-vK-MQg"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="qB9-dx-5RA"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ztZ-SV-NeE" firstAttribute="width" secondItem="wtM-GD-Zcf" secondAttribute="width" multiplier="0.5" id="H3l-mr-rD3"/>
+                            <constraint firstItem="20I-Iy-tuF" firstAttribute="centerX" secondItem="qB9-dx-5RA" secondAttribute="centerX" id="NGC-Ti-14N"/>
+                            <constraint firstItem="20I-Iy-tuF" firstAttribute="width" secondItem="ztZ-SV-NeE" secondAttribute="width" id="NOx-Ul-FEb"/>
+                            <constraint firstItem="20I-Iy-tuF" firstAttribute="top" secondItem="ztZ-SV-NeE" secondAttribute="bottom" constant="80" id="vO5-sa-8wn"/>
+                            <constraint firstItem="ztZ-SV-NeE" firstAttribute="centerY" secondItem="qB9-dx-5RA" secondAttribute="centerY" id="w92-VN-dpA"/>
+                            <constraint firstItem="ztZ-SV-NeE" firstAttribute="centerX" secondItem="qB9-dx-5RA" secondAttribute="centerX" id="yM3-FE-eEm"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="maxTempLabel" destination="W3M-f4-efm" id="PvC-Mc-pG1"/>
+                        <outlet property="minTempLabel" destination="w2X-kR-aOX" id="dL0-KK-0si"/>
+                        <outlet property="weatherImageView" destination="Z6I-AM-SIB" id="g6v-1P-G7U"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bfj-fq-gVr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="18.840579710144929" y="84.375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="Blue">
+            <color red="0.20499999821186066" green="0.53700000047683716" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Red">
+            <color red="1" green="0.210999995470047" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
@@ -12,7 +12,7 @@
         <!--Weather View Controller-->
         <scene sceneID="MUS-n8-Oys">
             <objects>
-                <viewController modalPresentationStyle="fullScreen" id="AUM-E2-vVA" customClass="WeatherViewController" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="AUM-E2-vVA" customClass="WeatherViewController" customModule="YumemiTraining" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wtM-GD-Zcf">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -1,0 +1,86 @@
+//
+//  WeatherViewController.swift
+//  YumemiTraining
+//
+//  Created by 水野虎樹 on 2022/02/18.
+//
+
+import UIKit
+import YumemiWeather
+
+protocol WeatherViewControllerDelegate: AnyObject {
+    func weatherViewControllerDidPressClose(_ viewController: WeatherViewController)
+}
+
+final class WeatherViewController: UIViewController {
+    
+    @IBOutlet private weak var weatherImageView: UIImageView!
+    @IBOutlet private weak var maxTempLabel: UILabel!
+    @IBOutlet private weak var minTempLabel: UILabel!
+    
+    weak var delegate: WeatherViewControllerDelegate?
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.loadWeather()
+    }
+
+    @IBAction private func reloadButtonDidPress(_ sender: Any) {
+        self.loadWeather()
+    }
+    
+    @IBAction private func closeButtonDidPress(_ sender: Any) {
+        self.delegate?.weatherViewControllerDidPressClose(self)
+    }
+    
+    private func loadWeather() {
+        
+        do {
+            // WeatherPrameterを作成
+            let weatherPrameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
+            
+            // 天気予報をAPIから取得
+            let weatherResult = try WeatherAPIService.fetchWeather(weatherPrameter)
+            
+            // 天気の画像を設定
+            let weatherImageResource = self.weatherImageResource(weatherResult.weather)
+            self.weatherImageView.image = weatherImageResource.image
+            self.weatherImageView.tintColor = weatherImageResource.color
+            
+            //最高気温と最低気温を設定
+            self.minTempLabel.text = String(weatherResult.minTemp)
+            self.maxTempLabel.text = String(weatherResult.maxTemp)
+            
+        } catch YumemiWeatherError.invalidParameterError {
+            self.showErrorAlert(title: "天気情報の取得に失敗", message: "invalidParameterError")
+        } catch YumemiWeatherError.unknownError {
+            self.showErrorAlert(title: "天気情報の取得に失敗", message: "unknownError")
+        } catch {
+            print(error)
+        }
+        
+    }
+    
+    private func weatherImageResource(_ weather: String) -> (image: UIImage?, color: UIColor?) {
+        
+        switch weather {
+        case "sunny":
+            return (UIImage(named: "sunny"), .red)
+        case "cloudy":
+            return (UIImage(named: "cloudy"), .gray)
+        case "rainy":
+            return (UIImage(named: "rainy"), .blue)
+        default:
+            return (nil, nil)
+        }
+        
+    }
+    
+    private func showErrorAlert(title: String?, message: String?) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel)
+        alert.addAction(cancelAction)
+        self.present(alert, animated: true)
+    }
+}
+


### PR DESCRIPTION

## 概要 

[Session6. VC_LifeCycle](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/VC_Lifecycle.md)

## 修正内容 

- アプリ起動後すぐに天気予報画面にページ遷移
- CLOSEボタンの実装

|after|
|-----|
|![closeButton](https://user-images.githubusercontent.com/67317828/156727475-56f4c755-db6c-46fb-8602-cd5334be9c9a.gif)|