### PR TITLE
フォアグラウンドに戻ったときに天気予報をリロード

### DIFF
--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -21,6 +21,7 @@ final class WeatherViewController: UIViewController {
     weak var delegate: WeatherViewControllerDelegate?
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(foreground(notification:)),
                                                name: UIApplication.willEnterForegroundNotification,

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -47,11 +47,11 @@ final class WeatherViewController: UIViewController {
     private func loadWeather() {
         
         do {
-            // WeatherPrameterを作成
-            let weatherPrameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
+            // WeatherParameterを作成
+            let weatherParameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
             
             // 天気予報をAPIから取得
-            let weatherResult = try WeatherAPI.fetchWeather(weatherPrameter)
+            let weatherResult = try WeatherAPI.fetchWeather(weatherParameter)
             
             // 天気の画像を設定
             let weatherImageResource = self.weatherImageResource(weatherResult.weather)

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -20,6 +20,17 @@ final class WeatherViewController: UIViewController {
     
     weak var delegate: WeatherViewControllerDelegate?
     
+    override func viewDidLoad() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(foreground(notification:)),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+    
+    @objc private func foreground(notification: Notification) {
+        self.loadWeather()
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.loadWeather()

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -27,12 +27,12 @@ final class WeatherViewController: UIViewController {
                                                object: nil)
     }
     
-    @objc private func foreground(notification: Notification) {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         self.loadWeather()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    @objc private func foreground(notification: Notification) {
         self.loadWeather()
     }
 


### PR DESCRIPTION
## 概要 

[Session7. NotificationCenter](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md)

## 修正内容 

- NotificationCenterを用いて、アプリがフォアグラウンドに戻ったときに天気予報をリロード

|after| 
|-----| 
|![a](https://user-images.githubusercontent.com/67317828/157150405-1d0be5ba-e966-49be-b564-e6a8b0251556.gif)|