### PR TITLE
APIを非同期に処理

### DIFF
--- a/YumemiTraining/YumemiTraining/APIs/WeatherAPI.swift
+++ b/YumemiTraining/YumemiTraining/APIs/WeatherAPI.swift
@@ -19,7 +19,7 @@ enum WeatherAPI {
         guard let weatherParameterJsonStr = String(data: weatherParameterData, encoding: .utf8) else {
             throw FetchWeatherError.decodeDataFailed
         }
-        let weatherResultJsonStr = try YumemiWeather.fetchWeather(weatherParameterJsonStr)
+        let weatherResultJsonStr = try YumemiWeather.syncFetchWeather(weatherParameterJsonStr)
         guard let weatherResultData = weatherResultJsonStr.data(using: String.Encoding.utf8) else {
             throw FetchWeatherError.encodeDataFailed
         }

--- a/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
@@ -70,6 +70,9 @@
                                     </button>
                                 </subviews>
                             </stackView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="Fqo-X7-mR5">
+                                <rect key="frame" x="197" y="604.5" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qB9-dx-5RA"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -77,12 +80,15 @@
                             <constraint firstItem="ztZ-SV-NeE" firstAttribute="width" secondItem="wtM-GD-Zcf" secondAttribute="width" multiplier="0.5" id="H3l-mr-rD3"/>
                             <constraint firstItem="20I-Iy-tuF" firstAttribute="centerX" secondItem="qB9-dx-5RA" secondAttribute="centerX" id="NGC-Ti-14N"/>
                             <constraint firstItem="20I-Iy-tuF" firstAttribute="width" secondItem="ztZ-SV-NeE" secondAttribute="width" id="NOx-Ul-FEb"/>
+                            <constraint firstItem="Fqo-X7-mR5" firstAttribute="top" secondItem="ztZ-SV-NeE" secondAttribute="bottom" constant="30" id="TW5-ZD-hj0"/>
+                            <constraint firstItem="Fqo-X7-mR5" firstAttribute="centerX" secondItem="qB9-dx-5RA" secondAttribute="centerX" id="tb3-qG-Vat"/>
                             <constraint firstItem="20I-Iy-tuF" firstAttribute="top" secondItem="ztZ-SV-NeE" secondAttribute="bottom" constant="80" id="vO5-sa-8wn"/>
                             <constraint firstItem="ztZ-SV-NeE" firstAttribute="centerY" secondItem="qB9-dx-5RA" secondAttribute="centerY" id="w92-VN-dpA"/>
                             <constraint firstItem="ztZ-SV-NeE" firstAttribute="centerX" secondItem="qB9-dx-5RA" secondAttribute="centerX" id="yM3-FE-eEm"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="activityIndicatorView" destination="Fqo-X7-mR5" id="caS-d9-xd3"/>
                         <outlet property="maxTempLabel" destination="W3M-f4-efm" id="PvC-Mc-pG1"/>
                         <outlet property="minTempLabel" destination="w2X-kR-aOX" id="dL0-KK-0si"/>
                         <outlet property="weatherImageView" destination="Z6I-AM-SIB" id="g6v-1P-G7U"/>

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -22,6 +22,7 @@ final class WeatherViewController: UIViewController {
     weak var delegate: WeatherViewControllerDelegate?
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(foreground(notification:)),
                                                name: UIApplication.willEnterForegroundNotification,

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -17,6 +17,7 @@ final class WeatherViewController: UIViewController {
     @IBOutlet private weak var weatherImageView: UIImageView!
     @IBOutlet private weak var maxTempLabel: UILabel!
     @IBOutlet private weak var minTempLabel: UILabel!
+    @IBOutlet private weak var activityIndicatorView: UIActivityIndicatorView!
     
     weak var delegate: WeatherViewControllerDelegate?
     
@@ -46,30 +47,43 @@ final class WeatherViewController: UIViewController {
     
     private func loadWeather() {
         
-        do {
-            // WeatherPrameterを作成
-            let weatherPrameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
-            
-            // 天気予報をAPIから取得
-            let weatherResult = try WeatherAPI.fetchWeather(weatherPrameter)
-            
-            // 天気の画像を設定
-            let weatherImageResource = self.weatherImageResource(weatherResult.weather)
-            self.weatherImageView.image = weatherImageResource.image
-            self.weatherImageView.tintColor = weatherImageResource.color
-            
-            //最高気温と最低気温を設定
-            self.minTempLabel.text = String(weatherResult.minTemp)
-            self.maxTempLabel.text = String(weatherResult.maxTemp)
-            
-        } catch YumemiWeatherError.invalidParameterError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "invalidParameterError")
-        } catch YumemiWeatherError.unknownError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "unknownError")
-        } catch {
-            print(error)
-        }
+        // weatherPrameterを作成
+        let weatherPrameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
         
+        // 天気予報をAPIから取得
+        self.activityIndicatorView.startAnimating()
+        DispatchQueue.global().async {
+            let weatherResult = Result { try WeatherAPI.fetchWeather(weatherPrameter)}
+            DispatchQueue.main.async {
+                self.activityIndicatorView.stopAnimating()
+                
+                // weatherResultをハンドリング
+                switch weatherResult {
+                case .success(let data):
+                    // 天気の画像を設定
+                    let weatherImageResource = self.weatherImageResource(data.weather)
+                    self.weatherImageView.image = weatherImageResource.image
+                    self.weatherImageView.tintColor = weatherImageResource.color
+                    //最高気温と最低気温を設定
+                    self.minTempLabel.text = String(data.minTemp)
+                    self.maxTempLabel.text = String(data.maxTemp)
+                case .failure(let error):
+                    let message: String
+                    switch error {
+                    case WeatherAPI.FetchWeatherError.decodeDataFailed:
+                        message = "JSONエンコードに失敗"
+                    case WeatherAPI.FetchWeatherError.decodeDataFailed:
+                        message = "JSONデコードに失敗"
+                    case YumemiWeatherError.unknownError:
+                        message = "天気情報の取得に失敗"
+                    default:
+                        message = "エラー発生"
+                    }
+                    self.showErrorAlert(title: "Error", message: message)
+                }
+            }
+        }
+            
     }
     
     private func weatherImageResource(_ weather: String) -> (image: UIImage?, color: UIColor?) {

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -48,29 +48,8 @@ final class WeatherViewController: UIViewController {
     
     private func loadWeather() {
         
-        do {
-            // WeatherParameterを作成
-            let weatherParameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
-            
-            // 天気予報をAPIから取得
-            let weatherResult = try WeatherAPI.fetchWeather(weatherParameter)
-            
-            // 天気の画像を設定
-            let weatherImageResource = self.weatherImageResource(weatherResult.weather)
-            self.weatherImageView.image = weatherImageResource.image
-            self.weatherImageView.tintColor = weatherImageResource.color
-            
-            //最高気温と最低気温を設定
-            self.minTempLabel.text = String(weatherResult.minTemp)
-            self.maxTempLabel.text = String(weatherResult.maxTemp)
-            
-        } catch YumemiWeatherError.invalidParameterError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "invalidParameterError")
-        } catch YumemiWeatherError.unknownError {
-            self.showErrorAlert(title: "天気情報の取得に失敗", message: "unknownError")
-        } catch {
-            print(error)
-        }
+        // WeatherParameterを作成
+        let weatherParameter = WeatherParameter(area: "tokyo", date: "2020-04-01T12:00:00+09:00")
         
         // 天気予報をAPIから取得
         self.activityIndicatorView.startAnimating()

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -75,7 +75,7 @@ final class WeatherViewController: UIViewController {
         // 天気予報をAPIから取得
         self.activityIndicatorView.startAnimating()
         DispatchQueue.global().async {
-            let weatherResult = Result { try WeatherAPI.fetchWeather(weatherPrameter) }
+            let weatherResult = Result { try WeatherAPI.fetchWeather(weatherParameter) }
             DispatchQueue.main.async {
                 self.activityIndicatorView.stopAnimating()
                 

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -74,7 +74,7 @@ final class WeatherViewController: UIViewController {
         // 天気予報をAPIから取得
         self.activityIndicatorView.startAnimating()
         DispatchQueue.global().async {
-            let weatherResult = Result { try WeatherAPI.fetchWeather(weatherPrameter)}
+            let weatherResult = Result { try WeatherAPI.fetchWeather(weatherPrameter) }
             DispatchQueue.main.async {
                 self.activityIndicatorView.stopAnimating()
                 

--- a/YumemiTraining/YumemiTraining/WeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.swift
@@ -53,9 +53,10 @@ final class WeatherViewController: UIViewController {
         
         // 天気予報をAPIから取得
         self.activityIndicatorView.startAnimating()
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [weak self] in
             let weatherResult = Result { try WeatherAPI.fetchWeather(weatherParameter) }
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 self.activityIndicatorView.stopAnimating()
                 
                 // weatherResultをハンドリング


### PR DESCRIPTION
## 概要 

[Session9. スレッドブロック](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md)

## 修正内容 

- 呼び出しAPIを`Sync ver`に変更する
- 非同期にAPIを呼び出す
- APIの処理が戻るまでUIActivityIndicatorを表示する
- Result型を用いてAPIの戻り値をハンドリング

|after| 
|-----| 
|![a](https://user-images.githubusercontent.com/67317828/157164424-cade9abd-8be0-43ae-879c-1de438aa438d.gif)| 