### PR TITLE
ReactiveSwiftを使用してページ遷移

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		B3D5259C27D1BD68002D7A4D /* WeatherViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */; };
 		B3D5259E27D1BEA3002D7A4D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5259D27D1BEA3002D7A4D /* ViewController.swift */; };
 		B3D525A427D887C7002D7A4D /* WeatherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D525A327D887C7002D7A4D /* WeatherModel.swift */; };
+		B3D525A727DAEB45002D7A4D /* ReactiveViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3D525A627DAEB45002D7A4D /* ReactiveViewController.storyboard */; };
+		B3D525A927DAF4B9002D7A4D /* ReactiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D525A827DAF4B9002D7A4D /* ReactiveViewController.swift */; };
+		B3D525AB27DAFD3C002D7A4D /* ReactiveWeatherViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3D525AA27DAFD3C002D7A4D /* ReactiveWeatherViewController.storyboard */; };
+		B3D525AD27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D525AC27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +48,10 @@
 		B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WeatherViewController.storyboard; sourceTree = "<group>"; };
 		B3D5259D27D1BEA3002D7A4D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		B3D525A327D887C7002D7A4D /* WeatherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherModel.swift; sourceTree = "<group>"; };
+		B3D525A627DAEB45002D7A4D /* ReactiveViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReactiveViewController.storyboard; sourceTree = "<group>"; };
+		B3D525A827DAF4B9002D7A4D /* ReactiveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactiveViewController.swift; sourceTree = "<group>"; };
+		B3D525AA27DAFD3C002D7A4D /* ReactiveWeatherViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReactiveWeatherViewController.storyboard; sourceTree = "<group>"; };
+		B3D525AC27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactiveWeatherViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +89,8 @@
 				B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */,
 				B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */,
 				B3D5259D27D1BEA3002D7A4D /* ViewController.swift */,
+				B3D525A827DAF4B9002D7A4D /* ReactiveViewController.swift */,
+				B3D525AC27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift */,
 				B3AF310827BF99EE00A7C1DB /* WeatherViewController.swift */,
 				43BF2CE327DAD46900A5B64B /* SampleViewController.swift */,
 				B3D5259A27D1B1D6002D7A4D /* APIs */,
@@ -88,6 +98,8 @@
 				43DC39CB27DAD24E009497D3 /* RootTabBarController.storyboard */,
 				B3AF310A27BF99EE00A7C1DB /* ViewController.storyboard */,
 				B3D5259B27D1BD68002D7A4D /* WeatherViewController.storyboard */,
+				B3D525A627DAEB45002D7A4D /* ReactiveViewController.storyboard */,
+				B3D525AA27DAFD3C002D7A4D /* ReactiveWeatherViewController.storyboard */,
 				43BF2CE127DAD45400A5B64B /* SampleViewController.storyboard */,
 				B3AF310D27BF99EF00A7C1DB /* Assets.xcassets */,
 				B3AF310F27BF99EF00A7C1DB /* LaunchScreen.storyboard */,
@@ -180,6 +192,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3D525A727DAEB45002D7A4D /* ReactiveViewController.storyboard in Resources */,
+				B3D525AB27DAFD3C002D7A4D /* ReactiveWeatherViewController.storyboard in Resources */,
 				B3D5259C27D1BD68002D7A4D /* WeatherViewController.storyboard in Resources */,
 				B3AF311127BF99EF00A7C1DB /* LaunchScreen.storyboard in Resources */,
 				B3AF310E27BF99EF00A7C1DB /* Assets.xcassets in Resources */,
@@ -199,7 +213,9 @@
 				B3D5259627D1AAF0002D7A4D /* WeatherResult.swift in Sources */,
 				B3D5259927D1B112002D7A4D /* WeatherModelImpl.swift in Sources */,
 				B3AF310927BF99EE00A7C1DB /* WeatherViewController.swift in Sources */,
+				B3D525A927DAF4B9002D7A4D /* ReactiveViewController.swift in Sources */,
 				B3AF310527BF99EE00A7C1DB /* AppDelegate.swift in Sources */,
+				B3D525AD27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift in Sources */,
 				B3D5259E27D1BEA3002D7A4D /* ViewController.swift in Sources */,
 				B3D5259427D1AA93002D7A4D /* WeatherParameter.swift in Sources */,
 				B3D525A427D887C7002D7A4D /* WeatherModel.swift in Sources */,

--- a/YumemiTraining/YumemiTraining/ReactiveViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/ReactiveViewController.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--reactive-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="ReactiveViewController" customModule="YumemiTraining" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fix-hi-UwJ">
+                                <rect key="frame" x="148.5" y="413" width="117.5" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Show Weather"/>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="fix-hi-UwJ" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="ayX-HT-LZl"/>
+                            <constraint firstItem="fix-hi-UwJ" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="p0l-WY-KCb"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="reactive" image="square.and.arrow.up.fill" catalog="system" selectedImage="pencil.tip.crop.circle.badge.plus" id="eYR-IW-62b"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="button" destination="fix-hi-UwJ" id="jvq-jN-R1f"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20" y="52"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="pencil.tip.crop.circle.badge.plus" catalog="system" width="128" height="113"/>
+        <image name="square.and.arrow.up.fill" catalog="system" width="115" height="128"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/YumemiTraining/YumemiTraining/ReactiveViewController.swift
+++ b/YumemiTraining/YumemiTraining/ReactiveViewController.swift
@@ -1,0 +1,51 @@
+//
+//  ReactiveViewController.swift
+//  YumemiTraining
+//
+//  Created by 水野虎樹 on 2022/03/11.
+//
+
+import UIKit
+import ReactiveSwift
+import ReactiveCocoa
+
+final class ReactiveViewController: UIViewController {
+    @IBOutlet private weak var button: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.bind()
+    }
+    
+    private func bind() {
+        self.button.reactive.controlEvents(.touchUpInside).observeValues { [weak self] _ in
+            guard let self = self else { return }
+            do {
+                try self.showWeatherViewController()
+            } catch {
+                return
+            }
+        }
+        
+    }
+    
+    private func showWeatherViewController() throws {
+        let storyboard = UIStoryboard(name: "ReactiveWeatherViewController", bundle: nil)
+        let viewController = storyboard.instantiateInitialViewController { (coder) in
+            ReactiveWeatherViewController(coder: coder)
+        }
+        guard let viewController = viewController else {
+            fatalError()
+        }
+        viewController.delegate = self
+        self.present(viewController, animated: true)
+    }
+}
+
+// MARK: -ReactiveWeatherViewControllerDelegate
+
+extension ReactiveViewController: ReactiveWeatherViewControllerDelegate {
+    func reactiveWeatherViewControllerDidPressClose(_ viewController: ReactiveWeatherViewController) {
+        self.dismiss(animated: true)
+    }
+}

--- a/YumemiTraining/YumemiTraining/ReactiveViewController.swift
+++ b/YumemiTraining/YumemiTraining/ReactiveViewController.swift
@@ -19,17 +19,12 @@ final class ReactiveViewController: UIViewController {
     
     private func bind() {
         self.button.reactive.controlEvents(.touchUpInside).observeValues { [weak self] _ in
-            guard let self = self else { return }
-            do {
-                try self.showWeatherViewController()
-            } catch {
-                return
-            }
+            self?.showWeatherViewController()
         }
         
     }
     
-    private func showWeatherViewController() throws {
+    private func showWeatherViewController() {
         let storyboard = UIStoryboard(name: "ReactiveWeatherViewController", bundle: nil)
         let viewController = storyboard.instantiateInitialViewController { (coder) in
             ReactiveWeatherViewController(coder: coder)

--- a/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Reactive Weather View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController modalPresentationStyle="fullScreen" id="Y6W-OH-hqX" customClass="ReactiveWeatherViewController" customModule="YumemiTraining" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vGz-zu-W4Q">
+                                <rect key="frame" x="177" y="437.5" width="60.5" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Close"/>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vGz-zu-W4Q" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="CcO-1S-MbF"/>
+                            <constraint firstItem="vGz-zu-W4Q" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="IZu-IZ-RW5"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="button" destination="vGz-zu-W4Q" id="GBv-wu-o5E"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="90" y="52"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.swift
@@ -1,0 +1,36 @@
+//
+//  ReactiveWeatherViewController.swift
+//  YumemiTraining
+//
+//  Created by 水野虎樹 on 2022/03/11.
+//
+
+import UIKit
+import ReactiveSwift
+import ReactiveCocoa
+
+protocol ReactiveWeatherViewControllerDelegate: AnyObject {
+    func reactiveWeatherViewControllerDidPressClose(_ viewController: ReactiveWeatherViewController)
+}
+
+final class ReactiveWeatherViewController: UIViewController {
+    @IBOutlet weak var button: UIButton!
+    
+    weak var delegate: ReactiveWeatherViewControllerDelegate?
+    
+    deinit {
+        print(#function)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.bind()
+    }
+    
+    private func bind() {
+        self.button.reactive.controlEvents(.touchUpInside).observeValues { [weak self] _ in
+            guard let self = self else { return }
+            self.delegate?.reactiveWeatherViewControllerDidPressClose(self)
+        }
+    }
+}

--- a/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/ReactiveWeatherViewController.swift
@@ -14,7 +14,7 @@ protocol ReactiveWeatherViewControllerDelegate: AnyObject {
 }
 
 final class ReactiveWeatherViewController: UIViewController {
-    @IBOutlet weak var button: UIButton!
+    @IBOutlet private weak var button: UIButton!
     
     weak var delegate: ReactiveWeatherViewControllerDelegate?
     

--- a/YumemiTraining/YumemiTraining/RootTabBarController.storyboard
+++ b/YumemiTraining/YumemiTraining/RootTabBarController.storyboard
@@ -1,11 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20036.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="6kE-5R-UPg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="6kE-5R-UPg">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20018.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--ReactiveViewController-->
+        <scene sceneID="gZr-ay-y62">
+            <objects>
+                <viewControllerPlaceholder storyboardName="ReactiveViewController" id="YtO-ak-8oL" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="V1B-zw-whR"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="C1y-vd-Fpt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="56" y="-313"/>
+        </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="KJB-7G-0CT">
             <objects>
@@ -20,6 +30,7 @@
                     <connections>
                         <segue destination="hY6-c3-TKn" kind="relationship" relationship="viewControllers" id="6Cz-D5-yVf"/>
                         <segue destination="jen-RR-NZd" kind="relationship" relationship="viewControllers" id="iwx-4C-4rx"/>
+                        <segue destination="YtO-ak-8oL" kind="relationship" relationship="viewControllers" id="zfq-3U-oQp"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jnP-5c-1Tk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
+++ b/YumemiTraining/YumemiTraining/WeatherViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20036.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AUM-E2-vVA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AUM-E2-vVA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20018.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>


### PR DESCRIPTION
[training1. ReactiveSwiftでページ遷移](https://github.com/torakyun/yumemi_training/issues/24)

## 修正内容 

## 1つ目の画面
* 新たに、`ReactiveViewController` という名前の画面を作成して、RootTabBarControllerのタブに追加してください（真似できればしてください。わからなかったら聞いて貰えばOKです）
* ReactiveViewControllerに `Show Weather` というタイトルのボタンを設置してください
* ボタンを押したときに、次の2つ目の画面へ遷移してください。ただし、`addTarget` や `IBAction` を使用せずにReactiveSwiftの機能でボタンタップを検知してください

## 2つ目の画面
* さらに新しく、 `ReactiveWeatherViewController` という名前の画面を作成してください
* ReactiveWeatherViewControllerに `Close` というタイトルのボタンを設置してください
* `ReactiveWeatherViewControllerDelegate` を作成してボタンを押したとき画面を閉じることができるようにしてください。こちらもReactiveSwiftの機能でボタンタップを検知すること