### PR TITLE
アーキテクチャをMVVMに変更

### DIFF
--- a/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
+++ b/YumemiTraining/YumemiTraining.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		43BF2CE427DAD46900A5B64B /* SampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BF2CE327DAD46900A5B64B /* SampleViewController.swift */; };
 		43BF2CE727DAD8F000A5B64B /* ReactiveCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 43BF2CE627DAD8F000A5B64B /* ReactiveCocoa */; };
 		43DC39CC27DAD24E009497D3 /* RootTabBarController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43DC39CB27DAD24E009497D3 /* RootTabBarController.storyboard */; };
+		B34863C527EDC83000C41B42 /* ReactiveWeatherViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34863C427EDC83000C41B42 /* ReactiveWeatherViewModel.swift */; };
+		B34863C727EDC84200C41B42 /* ReactiveWeatherViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34863C627EDC84200C41B42 /* ReactiveWeatherViewModelType.swift */; };
 		B3AF310527BF99EE00A7C1DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */; };
 		B3AF310727BF99EE00A7C1DB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */; };
 		B3AF310927BF99EE00A7C1DB /* WeatherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AF310827BF99EE00A7C1DB /* WeatherViewController.swift */; };
@@ -34,6 +36,8 @@
 		43BF2CE127DAD45400A5B64B /* SampleViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SampleViewController.storyboard; sourceTree = "<group>"; };
 		43BF2CE327DAD46900A5B64B /* SampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleViewController.swift; sourceTree = "<group>"; };
 		43DC39CB27DAD24E009497D3 /* RootTabBarController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RootTabBarController.storyboard; sourceTree = "<group>"; };
+		B34863C427EDC83000C41B42 /* ReactiveWeatherViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactiveWeatherViewModel.swift; sourceTree = "<group>"; };
+		B34863C627EDC84200C41B42 /* ReactiveWeatherViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactiveWeatherViewModelType.swift; sourceTree = "<group>"; };
 		B3AF310127BF99EE00A7C1DB /* YumemiTraining.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YumemiTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3AF310427BF99EE00A7C1DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B3AF310627BF99EE00A7C1DB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -67,6 +71,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B368603027F2A24F0065AA70 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B34863C427EDC83000C41B42 /* ReactiveWeatherViewModel.swift */,
+				B34863C627EDC84200C41B42 /* ReactiveWeatherViewModelType.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B3AF30F827BF99EE00A7C1DB = {
 			isa = PBXGroup;
 			children = (
@@ -93,6 +106,7 @@
 				B3AF310D27BF99EF00A7C1DB /* Assets.xcassets */,
 				B3AF310F27BF99EF00A7C1DB /* LaunchScreen.storyboard */,
 				B3AF311227BF99EF00A7C1DB /* Info.plist */,
+				B368603027F2A24F0065AA70 /* ViewModel */,
 			);
 			path = YumemiTraining;
 			sourceTree = "<group>";
@@ -234,6 +248,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B34863C527EDC83000C41B42 /* ReactiveWeatherViewModel.swift in Sources */,
 				B3D5259627D1AAF0002D7A4D /* WeatherResult.swift in Sources */,
 				B3D5259927D1B112002D7A4D /* WeatherModelImpl.swift in Sources */,
 				B3AF310927BF99EE00A7C1DB /* WeatherViewController.swift in Sources */,
@@ -242,6 +257,7 @@
 				B3D525AD27DAFD5E002D7A4D /* ReactiveWeatherViewController.swift in Sources */,
 				B3D5259E27D1BEA3002D7A4D /* ViewController.swift in Sources */,
 				B3D5259427D1AA93002D7A4D /* WeatherParameter.swift in Sources */,
+				B34863C727EDC84200C41B42 /* ReactiveWeatherViewModelType.swift in Sources */,
 				B3D525A427D887C7002D7A4D /* WeatherModel.swift in Sources */,
 				B3AF310727BF99EE00A7C1DB /* SceneDelegate.swift in Sources */,
 				43BF2CE427DAD46900A5B64B /* SampleViewController.swift in Sources */,

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
@@ -12,10 +12,14 @@ import ReactiveCocoa
 final class ReactiveViewController: UIViewController {
     @IBOutlet private weak var button: UIButton!
     
+    // MARK: - UIViewController
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.bind()
     }
+    
+    // MARK: - Private
     
     private func bind() {
         self.button.reactive.controlEvents(.touchUpInside).observeValues { [weak self] _ in

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
@@ -16,12 +16,12 @@ final class ReactiveViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.bind()
+        self.setupBind()
     }
     
     // MARK: - Private
     
-    private func bind() {
+    private func setupBind() {
         self.button.reactive.controlEvents(.touchUpInside).observeValues { [weak self] _ in
             self?.showWeatherViewController()
         }

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveViewController.swift
@@ -31,7 +31,7 @@ final class ReactiveViewController: UIViewController {
     private func showWeatherViewController() {
         let storyboard = UIStoryboard(name: "ReactiveWeatherViewController", bundle: nil)
         let viewController = storyboard.instantiateInitialViewController { (coder) in
-            ReactiveWeatherViewController(coder: coder, weatherModel: WeatherModelImpl())
+            ReactiveWeatherViewController(coder: coder)
         }
         guard let viewController = viewController else {
             fatalError()

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -48,7 +48,7 @@ final class ReactiveWeatherViewController: UIViewController {
     private func setupBind() {
         // Viewで発生したイベント
         self.viewModel.inputs.viewDidAppear <~ self.reactive.viewDidAppear
-        self.viewModel.inputs.refresh <~ self.reloadButton.reactive.controlEvents(.touchUpInside).map { _ in }
+        self.viewModel.inputs.reloadButtonDidPress <~ self.reloadButton.reactive.controlEvents(.touchUpInside).map { _ in }
         // Modelの処理をViewに反映
         self.activityIndicatorView.reactive.isAnimating <~ self.viewModel.outputs.isActivityIndicatorViewAnimating
         self.reactive.updateWeather <~ self.viewModel.outputs.updateWeather

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -54,8 +54,8 @@ final class ReactiveWeatherViewController: UIViewController {
         // インジケーター
         self.activityIndicatorView.reactive.isAnimating <~ self.viewModel.outputs.isActivityIndicatorViewAnimating
         // 天気の画像
-        self.weatherImageView.reactive.image <~ self.viewModel.weatherImage
-        self.weatherImageView.reactive.tintColor <~ self.viewModel.weatherImageColor
+        self.weatherImageView.reactive.image <~ self.viewModel.image
+        self.weatherImageView.reactive.tintColor <~ self.viewModel.color
         // 気温
         self.minTempLabel.reactive.text <~ self.viewModel.minTemp
         self.maxTempLabel.reactive.text <~ self.viewModel.maxTemp

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -46,22 +46,11 @@ final class ReactiveWeatherViewController: UIViewController {
     // MARK: - Private
     
     private func setupBind() {
-        // 天気情報のリロード
-        // リロードを行うシグナル
-        let willReloadSignal = Signal.merge(
-            // フォアグラウンドに戻った
-            NotificationCenter.default.reactive
-                .notifications(forName: UIApplication.willEnterForegroundNotification, object: nil)
-                .map { _ in },
-            // viewDidAppearが実行された
-            self.reactive.viewDidAppear,
-            // Reloadボタンが押された
-            self.reloadButton.reactive.controlEvents(.touchUpInside).map { _ in }
-        )
-        // APIからデータを取得
-        self.viewModel.inputs.weatherParameter <~ willReloadSignal.map(value: ("tokyo", Date()))
+        // Viewで発生したイベント
+        self.viewModel.inputs.viewDidAppear <~ self.reactive.viewDidAppear
+        self.viewModel.inputs.refresh <~ self.reloadButton.reactive.controlEvents(.touchUpInside).map { _ in }
+        // Modelの処理をViewに反映
         self.activityIndicatorView.reactive.isAnimating <~ self.viewModel.outputs.loading
-        // Viewに反映
         self.reactive.updateWeather <~ self.viewModel.outputs.weatherResult
         self.reactive.showError <~ self.viewModel.outputs.error
         

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -42,12 +42,12 @@ final class ReactiveWeatherViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.bind()
+        self.setupBind()
     }
     
     // MARK: - Private
     
-    private func bind() {
+    private func setupBind() {
         // 天気情報のリロード
         // リロードを行うシグナル
         let willReloadSignal = Signal.merge(

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -50,9 +50,9 @@ final class ReactiveWeatherViewController: UIViewController {
         self.viewModel.inputs.viewDidAppear <~ self.reactive.viewDidAppear
         self.viewModel.inputs.refresh <~ self.reloadButton.reactive.controlEvents(.touchUpInside).map { _ in }
         // Modelの処理をViewに反映
-        self.activityIndicatorView.reactive.isAnimating <~ self.viewModel.outputs.loading
-        self.reactive.updateWeather <~ self.viewModel.outputs.weatherResult
-        self.reactive.showError <~ self.viewModel.outputs.error
+        self.activityIndicatorView.reactive.isAnimating <~ self.viewModel.outputs.isActivityIndicatorViewAnimating
+        self.reactive.updateWeather <~ self.viewModel.outputs.updateWeather
+        self.reactive.showError <~ self.viewModel.outputs.showError
         
         // フォアグラウンドに戻った時にUIAlertControllerが表示されていたら閉じる
         NotificationCenter.default.reactive

--- a/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
+++ b/YumemiTraining/YumemiTraining/Controllers/ReactiveWeather/ReactiveWeatherViewController.swift
@@ -25,6 +25,8 @@ final class ReactiveWeatherViewController: UIViewController {
     weak var delegate: ReactiveWeatherViewControllerDelegate?
     private let weatherModel: WeatherModel
     
+    // MARK: - UIViewController
+    
     required init?(coder: NSCoder, weatherModel: WeatherModel) {
         self.weatherModel = weatherModel
         super.init(coder: coder)
@@ -42,6 +44,8 @@ final class ReactiveWeatherViewController: UIViewController {
         super.viewDidLoad()
         self.bind()
     }
+    
+    // MARK: - Private
     
     private func bind() {
         // 天気情報のリロード

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -14,7 +14,7 @@ final class ReactiveWeatherViewModel {
     
     // input
     private let viewDidAppearPipe = Signal<Void, Never>.pipe()
-    private let refreshPipe = Signal<Void, Never>.pipe()
+    private let reloadButtonDidPressPipe = Signal<Void, Never>.pipe()
     
     init(model: WeatherModelImpl) {
         self.model = model
@@ -33,7 +33,7 @@ final class ReactiveWeatherViewModel {
                 .notifications(forName: UIApplication.willEnterForegroundNotification, object: nil)
                 .map { _ in },
             self.viewDidAppearPipe.output,
-            self.refreshPipe.output
+            self.reloadButtonDidPressPipe.output
         )
         self.load <~ willReloadSignal.map(value: ("tokyo", Date()))
     }
@@ -52,8 +52,8 @@ extension ReactiveWeatherViewModel: ReactiveWeatherViewModelInputs {
     var viewDidAppear: Signal<Void, Never>.Observer {
         self.viewDidAppearPipe.input
     }
-    var refresh: Signal<Void, Never>.Observer {
-        self.refreshPipe.input
+    var reloadButtonDidPress: Signal<Void, Never>.Observer {
+        self.reloadButtonDidPressPipe.input
     }
 }
 

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -63,13 +63,13 @@ extension ReactiveWeatherViewModel: ReactiveWeatherViewModelInputs {
 // MARK: - ReactiveWeatherViewModelOutputs
 
 extension ReactiveWeatherViewModel: ReactiveWeatherViewModelOutputs {
-    var weatherResult: Signal<WeatherResult, Never> {
+    var updateWeather: Signal<WeatherResult, Never> {
         self.load.values
     }
-    var error: Signal<Error, Never> {
+    var showError: Signal<Error, Never> {
         self.load.errors
     }
-    var loading: Property<Bool> {
+    var isActivityIndicatorViewAnimating: Property<Bool> {
         self.load.isExecuting
     }
 }

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -46,12 +46,12 @@ final class ReactiveWeatherViewModel: NSObject {
         )
         self.load <~ willReloadSignal.map(value: ("tokyo", Date()))
         
-        self.reactive.changeWeatherImage <~ self.load.values.map { $0.weather }
+        self.reactive.changeWeatherImageResource <~ self.load.values.map { $0.weather }
         self._maxTemp <~ self.load.values.map { String($0.maxTemp) }
         self._minTemp <~ self.load.values.map { String($0.minTemp) }
     }
     
-    fileprivate func changeWeatherImage(_ weather: String) {
+    fileprivate func changeWeatherImageResource(_ weather: String) {
         let image: (UIImage?, UIColor?)
         switch weather {
         case "sunny":
@@ -128,9 +128,9 @@ extension ReactiveWeatherViewModel: ReactiveWeatherViewModelOutputs {
 // MARK: - Reactive
 
 private extension Reactive where Base == ReactiveWeatherViewModel {
-    var changeWeatherImage: BindingTarget<String> {
+    var changeWeatherImageResource: BindingTarget<String> {
         self.makeBindingTarget { base, weather in
-            base.changeWeatherImage(weather)
+            base.changeWeatherImageResource(weather)
         }
     }
 }

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  ReactiveWeatherViewModel.swift
+//  YumemiTraining
+//
+//  Created by 水野虎樹 on 2022/03/25.
+//
+
+import Foundation
+import ReactiveSwift
+
+final class ReactiveWeatherViewModel: NSObject {
+    private let model: WeatherModelImpl
+    private let load: Action<(String, Date), WeatherResult, Error>
+    
+    // input
+    private let weatherParameterPipe = Signal<(String, Date), Never>.pipe()
+    
+    // MARK: - NSObject
+    
+    init(model: WeatherModelImpl) {
+        self.model = model
+        self.load = Action<(String, Date), WeatherResult, Error> { (area, date) in
+            model.fetchWeather(at: area, date: date)
+        }
+        
+        super.init()
+        self.setupBind()
+    }
+    
+    // MARK: - Private
+    private func setupBind() {
+        self.load <~ self.weatherParameterPipe.output
+    }
+}
+
+// MARK: - ReactiveWeatherViewModelType
+
+extension ReactiveWeatherViewModel: ReactiveWeatherViewModelType {
+    var inputs: ReactiveWeatherViewModelInputs { self }
+    var outputs: ReactiveWeatherViewModelOutputs { self }
+}
+
+// MARK: - ReactiveWeatherViewModelInputs
+
+extension ReactiveWeatherViewModel: ReactiveWeatherViewModelInputs {
+    var weatherParameter: Signal<(String, Date), Never>.Observer {
+        self.weatherParameterPipe.input
+    }
+}
+
+// MARK: - ReactiveWeatherViewModelOutputs
+
+extension ReactiveWeatherViewModel: ReactiveWeatherViewModelOutputs {
+    var weatherResult: Signal<WeatherResult, Never> {
+        self.load.values
+    }
+    var error: Signal<Error, Never> {
+        self.load.errors
+    }
+    var loading: Property<Bool> {
+        self.load.isExecuting
+    }
+}

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -17,8 +17,8 @@ final class ReactiveWeatherViewModel: NSObject {
     private let viewDidAppearPipe = Signal<Void, Never>.pipe()
     private let reloadButtonDidPressPipe = Signal<Void, Never>.pipe()
     // output
-    private let _weatherImage = MutableProperty<UIImage?>(nil)
-    private let _weatherImageColor = MutableProperty<UIColor>(.tintColor)
+    private let _image = MutableProperty<UIImage?>(nil)
+    private let _color = MutableProperty<UIColor>(.tintColor)
     private let _maxTemp = MutableProperty<String?>(nil)
     private let _minTemp = MutableProperty<String?>(nil)
     
@@ -64,9 +64,9 @@ final class ReactiveWeatherViewModel: NSObject {
             image = (nil, nil)
         }
         
-        self._weatherImage.value = image.0
+        self._image.value = image.0
         if let color = image.1 {
-            self._weatherImageColor.value = color
+            self._color.value = color
         }
     }
     
@@ -105,11 +105,11 @@ extension ReactiveWeatherViewModel: ReactiveWeatherViewModelInputs {
 // MARK: - ReactiveWeatherViewModelOutputs
 
 extension ReactiveWeatherViewModel: ReactiveWeatherViewModelOutputs {
-    var weatherImage: Property<UIImage?> {
-        Property<UIImage?>(self._weatherImage)
+    var image: Property<UIImage?> {
+        Property<UIImage?>(self._image)
     }
-    var weatherImageColor: Property<UIColor> {
-        Property<UIColor>(self._weatherImageColor)
+    var color: Property<UIColor> {
+        Property<UIColor>(self._color)
     }
     var maxTemp: Property<String?> {
         Property<String?>(self._maxTemp)

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModel.swift
@@ -8,7 +8,7 @@
 import UIKit
 import ReactiveSwift
 
-final class ReactiveWeatherViewModel: NSObject {
+final class ReactiveWeatherViewModel {
     private let model: WeatherModelImpl
     private let load: Action<(String, Date), WeatherResult, Error>
     
@@ -16,15 +16,12 @@ final class ReactiveWeatherViewModel: NSObject {
     private let viewDidAppearPipe = Signal<Void, Never>.pipe()
     private let refreshPipe = Signal<Void, Never>.pipe()
     
-    // MARK: - NSObject
-    
     init(model: WeatherModelImpl) {
         self.model = model
         self.load = Action<(String, Date), WeatherResult, Error> { (area, date) in
             model.fetchWeather(at: area, date: date)
         }
         
-        super.init()
         self.setupBind()
     }
     

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -15,8 +15,8 @@ protocol ReactiveWeatherViewModelInputs {
 }
 
 protocol ReactiveWeatherViewModelOutputs {
-    var weatherImage: Property<UIImage?> { get }
-    var weatherImageColor: Property<UIColor> { get }
+    var image: Property<UIImage?> { get }
+    var color: Property<UIColor> { get }
     var maxTemp: Property<String?> { get }
     var minTemp: Property<String?> { get }
     var showErrorAlert: Signal<String, Never> { get }

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ReactiveSwift
+import UIKit
 
 protocol ReactiveWeatherViewModelInputs {
     var viewDidAppear: Signal<Void, Never>.Observer { get }
@@ -14,8 +15,11 @@ protocol ReactiveWeatherViewModelInputs {
 }
 
 protocol ReactiveWeatherViewModelOutputs {
-    var updateWeather: Signal<WeatherResult, Never> { get }
-    var showError: Signal<Error, Never> { get }
+    var weatherImage: Property<UIImage?> { get }
+    var weatherImageColor: Property<UIColor> { get }
+    var maxTemp: Property<String?> { get }
+    var minTemp: Property<String?> { get }
+    var showErrorAlert: Signal<String, Never> { get }
     var isActivityIndicatorViewAnimating: Property<Bool> { get }
 }
 

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -1,0 +1,24 @@
+//
+//  ReactiveWeatherViewModelType.swift
+//  YumemiTraining
+//
+//  Created by 水野虎樹 on 2022/03/25.
+//
+
+import Foundation
+import ReactiveSwift
+
+protocol ReactiveWeatherViewModelInputs {
+    var weatherParameter: Signal<(String, Date), Never>.Observer { get }
+}
+
+protocol ReactiveWeatherViewModelOutputs {
+    var weatherResult: Signal<WeatherResult, Never> { get }
+    var error: Signal<Error, Never> { get }
+    var loading: Property<Bool> { get }
+}
+
+protocol ReactiveWeatherViewModelType {
+    var inputs: ReactiveWeatherViewModelInputs { get }
+    var outputs: ReactiveWeatherViewModelOutputs { get }
+}

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -9,7 +9,8 @@ import Foundation
 import ReactiveSwift
 
 protocol ReactiveWeatherViewModelInputs {
-    var weatherParameter: Signal<(String, Date), Never>.Observer { get }
+    var viewDidAppear: Signal<Void, Never>.Observer { get }
+    var refresh: Signal<Void, Never>.Observer { get }
 }
 
 protocol ReactiveWeatherViewModelOutputs {

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -14,9 +14,9 @@ protocol ReactiveWeatherViewModelInputs {
 }
 
 protocol ReactiveWeatherViewModelOutputs {
-    var weatherResult: Signal<WeatherResult, Never> { get }
-    var error: Signal<Error, Never> { get }
-    var loading: Property<Bool> { get }
+    var updateWeather: Signal<WeatherResult, Never> { get }
+    var showError: Signal<Error, Never> { get }
+    var isActivityIndicatorViewAnimating: Property<Bool> { get }
 }
 
 protocol ReactiveWeatherViewModelType {

--- a/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
+++ b/YumemiTraining/YumemiTraining/ViewModel/ReactiveWeatherViewModelType.swift
@@ -10,7 +10,7 @@ import ReactiveSwift
 
 protocol ReactiveWeatherViewModelInputs {
     var viewDidAppear: Signal<Void, Never>.Observer { get }
-    var refresh: Signal<Void, Never>.Observer { get }
+    var reloadButtonDidPress: Signal<Void, Never>.Observer { get }
 }
 
 protocol ReactiveWeatherViewModelOutputs {


### PR DESCRIPTION
## 概要 

アーキテクチャをMVVMに変更

## 修正内容 

- ReactiveWeatherViewModel.swiftとReactiveWeatherViewModelType.swiftをViewModel内に作成
- ViewModelでModelの処理を行うように変更